### PR TITLE
Header and Cart Count - Fixes #9

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,15 @@
+import Header from "./components/Header";
 import ProductList from "./components/ProductList";
 
 const App = () => {
   return ( 
+    <>
+      <Header />
       <div className="min-h-screen bg-gray-100 p6">
         <h1 className="text-3xl font-bold mb-6">🛒 Product Catalog</h1>
         <ProductList />
       </div>
+    </>
    );
 }
  

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,0 +1,28 @@
+import { useCart } from "../context/CartContext";
+import {FaShoppingCart} from 'react-icons/fa'
+
+const Header = () => {
+    const {cart} = useCart();
+    const itemCount = cart.reduce((acc, item) => acc + item.qty, 0);
+
+    return (
+        <header className="bg-white shadow-md p-4 flex justify-between items-center">
+            <h1 className="text-2xl font-bold text-blue-600">
+                ShopDavid
+            </h1>
+            <div className="relative">
+                <FaShoppingCart className="text-2xl text-gray-700" />
+                {
+                    itemCount > 0 && (
+                        <span className="absolute -top-2 -right-2 bg-red-500 text-white text-xs w-5 h-5 flex items-center justify-center rounded-full">
+                            {itemCount}
+                        </span>
+                    )
+                }
+            </div>
+        </header>
+     );
+}
+
+export default Header;
+


### PR DESCRIPTION
# Test

Quand on clique sur **Add to Cart** :

- le Context met à jour `cart`
- `Header` réagit automatiquement et affiche la nouvelle valeur
- si on rafraîchis → tout disparaît (normal pour l’instant : pas encore de localStorage)

---

# ✔️ Résultat final

Grâce au Context :

- Tous les composants qui utilisent `useCart()` réagissent automatiquement.
- Le Header affiche le nombre total d’articles, même si les produits sont ajoutés depuis une autre page.
- Aucun passage de props inutile → architecture propre et scalable.